### PR TITLE
bugfix: mcService clusterIP is empty when cluster added at the first time

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -417,9 +417,10 @@ func (s *Proxy) addCluster(obj interface{}) {
 		}
 	}
 
+	klog.V(4).Infof("mcService.Spec.ClusterIP '%s', service.Spec.ClusterIP '%s'", mcService.Spec.ClusterIP, service.Spec.ClusterIP)
 	// populates the kubernetes apiEndpoint and kubesphere apiEndpoint
-	cluster.Spec.Connection.KubernetesAPIEndpoint = fmt.Sprintf("https://%s:%d", mcService.Spec.ClusterIP, kubernetesPort)
-	cluster.Spec.Connection.KubeSphereAPIEndpoint = fmt.Sprintf("http://%s:%d", mcService.Spec.ClusterIP, kubespherePort)
+	cluster.Spec.Connection.KubernetesAPIEndpoint = fmt.Sprintf("https://%s:%d", service.Spec.ClusterIP, kubernetesPort)
+	cluster.Spec.Connection.KubeSphereAPIEndpoint = fmt.Sprintf("http://%s:%d", service.Spec.ClusterIP, kubespherePort)
 
 	initializedCondition := v1alpha1.ClusterCondition{
 		Type:               v1alpha1.ClusterInitialized,


### PR DESCRIPTION
In fact, client-go doesn't update the mcService passed in. The real service  object can only be get from the response