### PR TITLE
feat: support export proxyed kubeapi to public

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,25 @@ node1    Ready    worker   2d3h   v1.17.3
 node2    Ready    worker   2d3h   v1.17.3
 node3    Ready    worker   2d3h   v1.17.3
 ```
+
+* Use tower to make a member cluster kubeapi accessable to public
+  
+If you want to make you member cluster kubeapi accessable to public, create a cluster resource as follows:
+
+```
+apiVersion: cluster.kubesphere.io/v1alpha1
+kind: Cluster
+metadata:
+  name: kind-test
+  namespace: kubesphere-system
+  annotations:
+    tower.kubesphere.io/external-lb-service-annoations: '{"eip.porter.kubesphere.io/v1alpha2":"porter-bgp-eip","lb.kubesphere.io/v1alpha1":"porter","protocol.porter.kubesphere.io/v1alpha1":"bgp"}'
+spec:
+  connection:
+    type: proxy
+    token: ""
+  joinFederation: true
+  externalKubeAPIEnabled: true
+```
+
+With `externalKubeAPIEnabled=true` and `connection.type=proxy` tower will create the serivce with `LoadBlancer` type, content in annotation with key `tower.kubesphere.io/external-lb-service-annoations` will be applied to the service anntations as k-v, so that your can control how the `ccm` process the service.

--- a/config/crd/bases/cluster.kubesphere.io_clusters.yaml
+++ b/config/crd/bases/cluster.kubesphere.io_clusters.yaml
@@ -1,26 +1,13 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: clusters.cluster.kubesphere.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.joinFederation
-    name: Federated
-    type: boolean
-  - JSONPath: .spec.provider
-    name: Provider
-    type: string
-  - JSONPath: .spec.enable
-    name: Active
-    type: boolean
-  - JSONPath: .status.kubernetesVersion
-    name: Version
-    type: string
   group: cluster.kubesphere.io
   names:
     kind: Cluster
@@ -28,138 +15,160 @@ spec:
     plural: clusters
     singular: cluster
   scope: Cluster
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: Cluster is the schema for the clusters API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            connection:
-              description: Connection holds info to connect to the member cluster
-              properties:
-                kubeconfig:
-                  description: KubeConfig content used to connect to cluster api server
-                    Should provide this field explicitly if connection type is direct.
-                    Will be populated by ks-proxy if connection type is proxy.
-                  format: byte
-                  type: string
-                kubernetesAPIEndpoint:
-                  description: Kubernetes API Server endpoint. This can be a hostname,
-                    hostname:port, IP or IP:port. Should provide this field explicitly
-                    if connection type is direct. Will be populated by ks-apiserver
-                    if connection type is proxy.
-                  type: string
-                kubernetesAPIServerPort:
-                  description: KubeAPIServerPort is the port which listens for forwarding
-                    kube-apiserver traffic Only applicable when connection type is
-                    proxy.
-                  type: integer
-                kubesphereAPIEndpoint:
-                  description: KubeSphere API Server endpoint. This can be a hostname,
-                    hostname:port, IP or IP:port. Should provide this field explicitly
-                    if connection type is direct. Will be populated by ks-apiserver
-                    if connection type is proxy.
-                  type: string
-                kubesphereAPIServerPort:
-                  description: KubeSphereAPIServerPort is the port which listens for
-                    forwarding kubesphere apigateway traffic Only applicable when
-                    connection type is proxy.
-                  type: integer
-                token:
-                  description: Token used by agents of member cluster to connect to
-                    host cluster proxy. This field is populated by apiserver only
-                    if connection type is proxy.
-                  type: string
-                type:
-                  description: type defines how host cluster will connect to host
-                    cluster ConnectionTypeDirect means direct connection, this requires   kubeconfig
-                    and kubesphere apiserver endpoint provided ConnectionTypeProxy
-                    means using kubesphere proxy, no kubeconfig   or kubesphere apiserver
-                    endpoint required
-                  type: string
-              type: object
-            enable:
-              description: Desired state of the cluster
-              type: boolean
-            joinFederation:
-              description: Join cluster as a kubefed cluster
-              type: boolean
-            provider:
-              description: Provider of the cluster, this field is just for description
-              type: string
-          type: object
-        status:
-          properties:
-            conditions:
-              description: Represents the latest available observations of a cluster's
-                current state.
-              items:
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.joinFederation
+      name: Federated
+      type: boolean
+    - jsonPath: .spec.provider
+      name: Provider
+      type: string
+    - jsonPath: .spec.enable
+      name: Active
+      type: boolean
+    - jsonPath: .status.kubernetesVersion
+      name: Version
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Cluster is the schema for the clusters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              connection:
+                description: Connection holds info to connect to the member cluster
                 properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
+                  externalKubernetesAPIEndpoint:
+                    description: External Kubernetes API Server endpoint Will be populated
+                      by tower if connection type is proxy and ExternalKubeAPIEnabled
+                      is true.
                     type: string
-                  lastUpdateTime:
-                    description: The last time this condition was updated.
-                    format: date-time
+                  kubeconfig:
+                    description: KubeConfig content used to connect to cluster api
+                      server Should provide this field explicitly if connection type
+                      is direct. Will be populated by ks-proxy if connection type
+                      is proxy.
+                    format: byte
                     type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
+                  kubernetesAPIEndpoint:
+                    description: Kubernetes API Server endpoint. This can be a hostname,
+                      hostname:port, IP or IP:port. Should provide this field explicitly
+                      if connection type is direct. Will be populated by ks-apiserver
+                      if connection type is proxy.
                     type: string
-                  reason:
-                    description: The reason for the condition's last transition.
+                  kubernetesAPIServerPort:
+                    description: KubeAPIServerPort is the port which listens for forwarding
+                      kube-apiserver traffic Only applicable when connection type
+                      is proxy.
+                    type: integer
+                  kubesphereAPIEndpoint:
+                    description: KubeSphere API Server endpoint. This can be a hostname,
+                      hostname:port, IP or IP:port. Should provide this field explicitly
+                      if connection type is direct. Will be populated by ks-apiserver
+                      if connection type is proxy.
                     type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
+                  kubesphereAPIServerPort:
+                    description: KubeSphereAPIServerPort is the port which listens
+                      for forwarding kubesphere apigateway traffic Only applicable
+                      when connection type is proxy.
+                    type: integer
+                  token:
+                    description: Token used by agents of member cluster to connect
+                      to host cluster proxy. This field is populated by apiserver
+                      only if connection type is proxy.
                     type: string
                   type:
-                    description: Type of the condition
+                    description: type defines how host cluster will connect to host
+                      cluster ConnectionTypeDirect means direct connection, this requires   kubeconfig
+                      and kubesphere apiserver endpoint provided ConnectionTypeProxy
+                      means using kubesphere proxy, no kubeconfig   or kubesphere
+                      apiserver endpoint required
                     type: string
-                required:
-                - status
-                - type
                 type: object
-              type: array
-            kubernetesVersion:
-              description: GitVersion of the kubernetes cluster, this field is populated
-                by cluster controller
-              type: string
-            nodeCount:
-              description: Count of the kubernetes cluster nodes This field may not
-                reflect the instant status of the cluster.
-              type: integer
-            region:
-              description: Region is the name of the region in which all of the nodes
-                in the cluster exist.  e.g. 'us-east1'.
-              type: string
-            zones:
-              description: Zones are the names of availability zones in which the
-                nodes of the cluster exist, e.g. 'us-east1-a'.
-              items:
+              enable:
+                description: Desired state of the cluster
+                type: boolean
+              externalKubeAPIEnabled:
+                description: ExternalKubeAPIEnabled export kubeapiserver to public
+                  use a lb type service if connection type is proxy
+                type: boolean
+              joinFederation:
+                description: Join cluster as a kubefed cluster
+                type: boolean
+              provider:
+                description: Provider of the cluster, this field is just for description
                 type: string
-              type: array
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Represents the latest available observations of a cluster's
+                  current state.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of the condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              kubernetesVersion:
+                description: GitVersion of the kubernetes cluster, this field is populated
+                  by cluster controller
+                type: string
+              nodeCount:
+                description: Count of the kubernetes cluster nodes This field may
+                  not reflect the instant status of the cluster.
+                type: integer
+              region:
+                description: Region is the name of the region in which all of the
+                  nodes in the cluster exist.  e.g. 'us-east1'.
+                type: string
+              zones:
+                description: Zones are the names of availability zones in which the
+                  nodes of the cluster exist, e.g. 'us-east1-a'.
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/apis/cluster/v1alpha1/cluster_types.go
+++ b/pkg/apis/cluster/v1alpha1/cluster_types.go
@@ -32,6 +32,9 @@ type ClusterSpec struct {
 
 	// Connection holds info to connect to the member cluster
 	Connection Connection `json:"connection,omitempty"`
+
+	// ExternalKubeAPIEnabled export kubeapiserver to public use a lb type service if connection type is proxy
+	ExternalKubeAPIEnabled bool `json:"externalKubeAPIEnabled,omitempty"`
 }
 
 type ConnectionType string
@@ -62,6 +65,10 @@ type Connection struct {
 	// Will be populated by ks-apiserver if connection type is proxy.
 	KubernetesAPIEndpoint string `json:"kubernetesAPIEndpoint,omitempty"`
 
+	// External Kubernetes API Server endpoint
+	// Will be populated by tower if connection type is proxy and ExternalKubeAPIEnabled is true.
+	ExternalKubernetesAPIEndpoint string `json:"externalKubernetesAPIEndpoint,omitempty"`
+
 	// KubeConfig content used to connect to cluster api server
 	// Should provide this field explicitly if connection type is direct.
 	// Will be populated by ks-proxy if connection type is proxy.
@@ -91,6 +98,9 @@ const (
 
 	// Cluster has been one of federated clusters
 	ClusterFederated ClusterConditionType = "Federated"
+
+	// Cluster external ready
+	ClusterExternalAccessReady ClusterConditionType = "ExternalAccessReady"
 
 	// Cluster is all available for requests
 	ClusterReady ClusterConditionType = "Ready"

--- a/pkg/certs/cert.go
+++ b/pkg/certs/cert.go
@@ -5,13 +5,14 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
+	"net"
+	"time"
+
 	"github.com/pkg/errors"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/keyutil"
-	"net"
-	"time"
 )
 
 const (
@@ -150,7 +151,7 @@ func BuildKubeConfigFromSpec(spec *KubeConfigSpec, clustername string) (*clientc
 }
 
 type CertificateIssuer interface {
-	IssueCertAndKey(ip string, dnsNames ...string) ([]byte, []byte, error)
+	IssueCertAndKey(ips []string, dnsNames []string) ([]byte, []byte, error)
 	IssueKubeConfig(clusterName string, apiServer string) ([]byte, error)
 }
 
@@ -193,7 +194,7 @@ func (s *simpleCertificateIssuer) IssueKubeConfig(clusterName string, apiServer 
 }
 
 // IssueCertAndKey issues certificate and key,
-func (s *simpleCertificateIssuer) IssueCertAndKey(ip string, dns ...string) ([]byte, []byte, error) {
+func (s *simpleCertificateIssuer) IssueCertAndKey(ips []string, dns []string) ([]byte, []byte, error) {
 	altNames := certutil.AltNames{
 		DNSNames: defaultAltNamesDNS,
 		IPs:      make([]net.IP, 0),
@@ -203,7 +204,7 @@ func (s *simpleCertificateIssuer) IssueCertAndKey(ip string, dns ...string) ([]b
 		altNames.DNSNames = append(altNames.DNSNames, dns...)
 	}
 
-	if len(ip) != 0 {
+	for _, ip := range ips {
 		altNames.IPs = append(altNames.IPs, net.ParseIP(ip))
 	}
 


### PR DESCRIPTION
Signed-off-by: lxm <lxm.xupt@gmail.com>

tower has made kubeapiserver accessable for host cluster to member cluster.

And in some cases, we need to reach member kubeapiserver, so I've made this pr.

An example to enable this feature use cluster config is as follow.
We just need to set `externalKubeAPIEnabled` to `true` and then tower will create a service with `LoadBlancer` type
the purpose of the annotation key `tower.kubesphere.io/external-lb` is to add some  annotations to the service so that we can control `ccm` to process this serivce.

```
apiVersion: cluster.kubesphere.io/v1alpha1
kind: Cluster
metadata:
  name: kind-test
  namespace: kubesphere-system
  annotations:
    tower.kubesphere.io/external-lb: '{"eip.porter.kubesphere.io/v1alpha2":"porter-bgp-eip","lb.kubesphere.io/v1alpha1":"porter","protocol.porter.kubesphere.io/v1alpha1":"bgp"}'
spec:
  connection:
    type: proxy
    token: ""
  joinFederation: true
  externalKubeAPIEnabled: true
```

