### PR TITLE
Support for building multiple platform images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= kubespheredev/tower:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
@@ -70,6 +70,9 @@ generate: controller-gen
 # Build the docker image
 docker-build: test
 	docker build . -t ${IMG}
+
+docker-build-multiarch: test
+	docker buildx build --platform linux/amd64,linux/arm64 . -t ${IMG} --push
 
 # Push the docker image
 docker-push:


### PR DESCRIPTION
Use the docker buildx tool to build multi-platform images, eg: [iawia002/tower:5fdda0d](https://hub.docker.com/layers/183522063/iawia002/tower/5fdda0d/images/sha256-cba4c4f45becbb77f7e0d2b1f649c5551cf7d7e7eafb45cbac8c86f88eef3d56?context=repo)

<img width="1285" alt="Screen Shot 2021-12-20 at 5 21 35 PM" src="https://user-images.githubusercontent.com/9134003/146743573-67849461-8b01-45ce-95d4-064eb2772c79.png">

/cc @zryfish 