### PR TITLE
fix:return error when NewSshConn return nil

### DIFF
--- a/pkg/proxy/proxy_server.go
+++ b/pkg/proxy/proxy_server.go
@@ -77,7 +77,7 @@ func buildServerData(sshConn utils.GetSSHConn, host string, ca, cert, key, serve
 			if c == nil {
 				return nil, fmt.Errorf("no remote connetion available")
 			}
-			return utils.NewSshConn(sshConn, host), nil
+			return utils.NewSshConn(sshConn, host)
 		},
 	}
 


### PR DESCRIPTION
**Describe the bug**
when remove agent pod, proxy server will restart beacuse buildServerData.transport.DialContext return a nil conn.
<img width="600" alt="image" src="https://user-images.githubusercontent.com/19946334/163978184-5117152d-1272-4c9d-91ca-55fa5c035e6e.png">
