### PR TITLE
proxy: fix trim service name

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -669,7 +669,7 @@ func (s *Proxy) addSVC(obj interface{}) {
 		return
 	}
 	// get cluster by svc name
-	clusterName := strings.TrimLeft(svc.Name, svcPrefix)
+	clusterName := strings.TrimPrefix(svc.Name, svcPrefix)
 	cluster, err := s.clusterClient.ClusterV1alpha1().Clusters().Get(context.TODO(), clusterName, metav1.GetOptions{})
 	if err != nil {
 		klog.Errorf("get cluster with name[%s] failed. err:%v", clusterName, err)


### PR DESCRIPTION
```bash
 ./bin/proxy  --ca-cert ./tls/ca.crt --ca-key ./tls/ca.key --host 0.0.0.0 --port 38080 --publish-service-address 10.64.1.53  --kubeconfig ~/.kube/config
I0822 14:43:13.194914   69792 options.go:46] CA set to "./tls/ca.crt".
I0822 14:43:13.195067   69792 options.go:47] CA key file set to "./tls/ca.key".
I0822 14:43:13.195072   69792 options.go:48] Host set to 0.0.0.0
I0822 14:43:13.195075   69792 options.go:49] Agent port set to 38080.
I0822 14:43:13.195079   69792 options.go:50] Kubeconfig set to "/Users/icebergu/.kube/config".
I0822 14:43:13.195082   69792 options.go:51] Leader election set to false
I0822 14:43:14.114129   69792 proxy.go:335] Listening on 0.0.0.0:38080...
E0822 14:43:14.245497   69792 proxy.go:675] get cluster with name[luster-1] failed. err:clusters.cluster.kubesphere.io "luster-1" not found
I0822 14:43:21.423706   69792 proxy.go:275] Connection established with cluster-1
```

**E0822 14:43:14.245497   69792 proxy.go:675] get cluster with name[luster-1] failed. err:clusters.cluster.kubesphere.io "luster-1" not found**