### PR TITLE
Remove unused kubernetesApiserverSvc flags

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -15,6 +15,7 @@ func NewAgentCommand() *cobra.Command {
 		Use:  "Agent",
 		Long: "Agent client run in user cluster",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			o.Print()
 			if err := o.Validate(); err != nil {
 				return err
 			}

--- a/cmd/agent/app/options.go
+++ b/cmd/agent/app/options.go
@@ -31,7 +31,6 @@ func NewAgentRunOptions() *AgentRunOptions {
 func (o *AgentRunOptions) Flags() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("agent", pflag.ContinueOnError)
 	flags.StringVar(&o.AgentOptions.Name, "name", o.AgentOptions.Name, "Agent name")
-	flags.StringVar(&o.AgentOptions.KubernetesApiserverSvc, "kubernetes-service", "kubernetes.default.svc", "Kubernetes service name")
 	flags.StringVar(&o.AgentOptions.KubesphereApiserverSvc, "kubesphere-service", "ks-apiserver.kubesphere-system.svc", "KubeSphere service name")
 	flags.DurationVar(&o.AgentOptions.KeepAlive, "keepalive", o.AgentOptions.KeepAlive, "Keepalive duration")
 	flags.IntVar(&o.AgentOptions.MaxRetryCount, "max-retry", o.AgentOptions.MaxRetryCount, "Maximum retries, 0 means never stop")
@@ -79,7 +78,5 @@ func (o *AgentRunOptions) Print() {
 	klog.V(0).Infof("MaxRetryInterval set to %s\n", o.AgentOptions.MaxRetryInterval)
 	klog.V(0).Infof("Token set to %s\n", o.AgentOptions.Token)
 	klog.V(0).Infof("Kubeconfig set to %s\n", o.AgentOptions.Kubeconfig)
-	klog.V(0).Infof("Kubernetes service set to %s\n", o.AgentOptions.KubernetesApiserverSvc)
 	klog.V(0).Infof("Kubesphere service set to %s\n", o.AgentOptions.KubesphereApiserverSvc)
-
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -47,7 +47,6 @@ func NewAgent(options *Options) (*Agent, error) {
 		Name:              options.Name,
 		Token:             options.Token,
 		KubeSphereSvcHost: options.KubesphereApiserverSvc,
-		KubernetesSvcHost: options.KubernetesApiserverSvc,
 		Version:           version.BuildVersion,
 	}
 

--- a/pkg/agent/options.go
+++ b/pkg/agent/options.go
@@ -8,7 +8,6 @@ type Options struct {
 	KeepAlive              time.Duration
 	MaxRetryCount          int
 	MaxRetryInterval       time.Duration
-	KubernetesApiserverSvc string
 	KubesphereApiserverSvc string
 	Server                 string
 	Name                   string


### PR DESCRIPTION
Remove unused kubernetesApiserverSvc flags,Because we didn't use it to set the conf.KubernetesSvcHost.